### PR TITLE
ATLEDGE-464 SketchUpload recognizes Windows paths with spaces

### DIFF
--- a/clupload/cluploadArduino101_win.sh
+++ b/clupload/cluploadArduino101_win.sh
@@ -50,20 +50,20 @@ main() {
 	dbg_print "Waiting for device..."
 
 	COUNTER=0
-	$dfu_cmd -l  >"$tmp_dfu_output"
+	"$dfu_cmd" -l  >"$tmp_dfu_output"
 	f=$(find_string "sensor_core" "$tmp_dfu_output")
 	while [ "x$f" == "xnot_found" ] && [ $COUNTER -lt 10 ]
 	do
 		let COUNTER=COUNTER+1
-		$sleep 1
-		$dfu_cmd -l >"$tmp_dfu_output"
+		"$sleep" 1
+		"$dfu_cmd" -l >"$tmp_dfu_output"
 		f=$(find_string "sensor_core" "$tmp_dfu_output")
 	done
 
 	if [ "x$verbosity" == "xverbose" ] ; then
-		dfu_download="$dfu_cmd -D \"$bin_file_name\" -v --alt 7 -R"
+		dfu_download="\"$dfu_cmd\" -D \"$bin_file_name\" -v --alt 7 -R"
 	else
-		dfu_download="$dfu_cmd -D \"$bin_file_name\" --alt 7 -R >/dev/null 2>&1"
+		dfu_download="\"$dfu_cmd\" -D \"$bin_file_name\" --alt 7 -R >/dev/null 2>&1"
 	fi
 
 	if [ "x$f" == "xfound" ] ; then


### PR DESCRIPTION
Original issue was found in Win XP. Verified fix on Win 7 system with username containing a space (Brian Baltz).
